### PR TITLE
Make TimestampWriter.write_timestamp/2 `call` our GenServer instead o…

### DIFF
--- a/lib/stats_yard/timestamp_writer.ex
+++ b/lib/stats_yard/timestamp_writer.ex
@@ -6,7 +6,7 @@ defmodule StatsYard.TimestampWriter do
   ###
 
   def write_timestamp(filename, timestamp) do
-    GenServer.cast(__MODULE__, {:write_timestamp, filename, timestamp})
+    GenServer.call(__MODULE__, {:write_timestamp, filename, timestamp})
   end
 
   def start_link() do
@@ -21,8 +21,8 @@ defmodule StatsYard.TimestampWriter do
     {:ok, state}
   end
 
-  def handle_cast({:write_timestamp, filename, timestamp}, state) do
-    :ok = File.write(filename, "#{timestamp}")
-    {:noreply, state}
+  def handle_call({:write_timestamp, filename, timestamp}, _from, state) do
+    result = File.write(filename, "#{timestamp}")
+    {:reply, result, state}
   end
 end

--- a/test/stats_yard/timestamp_writer_test.exs
+++ b/test/stats_yard/timestamp_writer_test.exs
@@ -1,0 +1,8 @@
+defmodule StatsYard.TimestampWriterTest do
+  use ExUnit.Case
+
+  test "can write timestamp to a file" do
+    assert :ok == StatsYard.TimestampWriter.write_timestamp("tstamp_write.test", :os.system_time(1000))
+  end
+
+end

--- a/test/stats_yard_test.exs
+++ b/test/stats_yard_test.exs
@@ -1,8 +1,4 @@
 defmodule StatsYardTest do
   use ExUnit.Case
   doctest StatsYard
-
-  test "the truth" do
-    assert 1 + 1 == 2
-  end
 end


### PR DESCRIPTION
…f `cast` it. Add a basic test for TimestampWriter.