### PR TITLE
Make write_timestamp test cleaner and self-contained. Add basic types…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /deps
 erl_crash.dump
 *.ez
+**/.*.swp

--- a/lib/stats_yard/timestamp_writer.ex
+++ b/lib/stats_yard/timestamp_writer.ex
@@ -1,10 +1,25 @@
 defmodule StatsYard.TimestampWriter do
   use GenServer
 
+  @moduledoc """
+  This module is entirely devoted to writing timestamps to files.
+  """
+
   ###
   ### Public API
   ###
 
+  @doc """
+  Writes the given timestamp to the given filename.
+
+  ## Examples
+
+    iex> StatsYard.Timestampwriter.write_timestamp("/tmp/foo.time", :os.system_time(1000))
+    :ok
+
+  """
+
+  @spec write_timestamp(String.t, pos_integer) :: atom
   def write_timestamp(filename, timestamp) do
     GenServer.call(__MODULE__, {:write_timestamp, filename, timestamp})
   end

--- a/test/stats_yard/timestamp_writer_test.exs
+++ b/test/stats_yard/timestamp_writer_test.exs
@@ -1,8 +1,28 @@
 defmodule StatsYard.TimestampWriterTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
 
-  test "can write timestamp to a file" do
-    assert :ok == StatsYard.TimestampWriter.write_timestamp("tstamp_write.test", :os.system_time(1000))
+  setup context do
+    if cd = context[:cd] do
+      prev_cd = File.cwd!
+      File.cd!(cd)
+      on_exit fn ->
+        if tempfile = context[:tempfile] do
+          if File.exists?(tempfile) do
+            File.rm!(tempfile)
+          end
+        end
+
+        File.cd!(prev_cd)
+      end
+    end
+
+    :ok
+  end
+
+  @tag cd: "test/fixtures"
+  @tag tempfile: "tstamp_write.test"
+  test "can write timestamp to a file", context do
+    assert :ok == StatsYard.TimestampWriter.write_timestamp(context[:tempfile], :os.system_time(1000))
   end
 
 end


### PR DESCRIPTION
…pec and docs for TimestampWriter API