### PR TITLE
Fix unused variable warnings

### DIFF
--- a/test/stats_yard/data_point_test.exs
+++ b/test/stats_yard/data_point_test.exs
@@ -15,7 +15,7 @@ defmodule StatsYard.DataPointTest do
   test "can validate valid data points" do
     for valid_data_point <- @valid_data_points do
       assert capture_log([level: :debug], fn ->
-        assert {:ok, valid_data_point} = StatsYard.DataPoint.validate(valid_data_point)
+        assert {:ok, ^valid_data_point} = StatsYard.DataPoint.validate(valid_data_point)
       end) =~ "valid stat: #{inspect(valid_data_point)}"
     end
   end
@@ -23,7 +23,7 @@ defmodule StatsYard.DataPointTest do
   test "can invalidate invalid data points" do
     for invalid_data_point <- @invalid_data_points do
       assert capture_log([level: :info], fn ->
-        assert {:invalid, invalid_data_point} = StatsYard.DataPoint.validate(invalid_data_point)
+        assert {:invalid, ^invalid_data_point} = StatsYard.DataPoint.validate(invalid_data_point)
       end) =~ "invalid stat: #{inspect(invalid_data_point)}"
     end
   end


### PR DESCRIPTION
The reason why there was a warning is that effectively the following code used to _rebind_ the `valid_data_point ` variable:

```elixir
assert {:ok, valid_data_point} = StatsYard.DataPoint.validate(valid_data_point)
```

Later, the rebound value was not used at all, and it resulted in a warning.

So, what we probably want to do here is [pin](http://elixir-lang.org/getting-started/pattern-matching.html#the-pin-operator) the variable, like I did in this pull request.

Alternatively, we can use `==` instead of `=` in the `assert`. It fixes the warnings too. Like this:

```elixir
assert {:invalid, invalid_data_point} == StatsYard.DataPoint.validate(invalid_data_point)
```

Great articles by the way, I really enjoy reading them. Looking forward to the next post!